### PR TITLE
Temporarily use `root`-based Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             ./ci_support/fast_finish_ci_pr_build.sh
             ./ci_support/checkout_merge_commit.sh
       - run:
-          command: docker pull condaforge/linux-anvil
+          command: docker pull condaforge/linux-anvil@sha256:06450ec212b43cc103462419f271f29cff0cf67e802e63185b40a3ded02393c9
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,7 @@ cat << EOF | docker run -i \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
-                        condaforge/linux-anvil \
+                        condaforge/linux-anvil@sha256:06450ec212b43cc103462419f271f29cff0cf67e802e63185b40a3ded02393c9 \
                         bash || exit 1
 
 set -e

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,5 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
+docker:
+  image: condaforge/linux-anvil@sha256:06450ec212b43cc103462419f271f29cff0cf67e802e63185b40a3ded02393c9


### PR DESCRIPTION
Workaround for issue ( https://github.com/conda-forge/gawk-feedstock/issues/1 ).

This uses the last build of the `condaforge/linux-anvil` image, which still used `root`. No clue how long this image will remain available. So it would be ideal to switch off of it sooner rather than later. In the interim, this is a reasonable workaround to get Linux packages out.