### PR TITLE
Switch back to the latest `condaforge/linux-anvil` image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             ./ci_support/fast_finish_ci_pr_build.sh
             ./ci_support/checkout_merge_commit.sh
       - run:
-          command: docker pull condaforge/linux-anvil@sha256:06450ec212b43cc103462419f271f29cff0cf67e802e63185b40a3ded02393c9
+          command: docker pull condaforge/linux-anvil
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,7 @@ cat << EOF | docker run -i \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
-                        condaforge/linux-anvil@sha256:06450ec212b43cc103462419f271f29cff0cf67e802e63185b40a3ded02393c9 \
+                        condaforge/linux-anvil \
                         bash || exit 1
 
 set -e

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,5 +4,3 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
-docker:
-  image: condaforge/linux-anvil@sha256:06450ec212b43cc103462419f271f29cff0cf67e802e63185b40a3ded02393c9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   script:
     - ./configure --prefix="{{ PREFIX }}"


### PR DESCRIPTION
Fixes https://github.com/conda-forge/gawk-feedstock/issues/1

Switches back to the latest `condaforge/linux-anvil` image, which builds under a non-`root` user. Bump build number to `1` as the previous package was built under the `root` user and this one is not.