### PR TITLE
Add 4.2.1 and gettext dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,9 @@ build:
 requirements:
   build:
     - toolchain
+    - gettext  # [osx]
+  run:
+    - gettext  # [osx]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gawk" %}
-{% set version = "4.2.0" %}
-{% set sha256 = "c88046c6e8396ee548bcb941e16def809b7b55b60a1044b5dd254094f347c7d9" %}
+{% set version = "4.2.1" %}
+{% set sha256 = "2b23d51503b2df9a41aa6fddc6002ad7ebf2a386ac19dc1b6be0dd48b0acf6db" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   script:
     - ./configure --prefix="{{ PREFIX }}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,15 +17,15 @@ build:
   script:
     - ./configure --prefix="{{ PREFIX }}"
     - make -j${NUM_CPUS}
-    - make check -j${NUM_CPUS}
+    - make check -j
     - make install
 
 requirements:
   build:
     - toolchain
-    - gettext  # [osx]
+    - gettext
   run:
-    - gettext  # [osx]
+    - gettext
 
 test:
   commands:


### PR DESCRIPTION
Building off #4, this tries adding gettext to pass the the [failing test on osx](https://travis-ci.org/conda-forge/gawk-feedstock/builds/354445648#L1785). Found by googling [here](https://fossies.org/linux/gawk/README_d/README.macosx) (probably non canonical, but it got me there)...